### PR TITLE
Replace react-hot-loader

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,13 @@
+{
+  "stage": 0,
+  "plugins" : [
+    "react-transform"
+  ],
+  "extra"  : {
+    "react-transform": [{
+      "target"  : "react-transform-hmr",
+      "imports" : ["react"],
+      "locals"  : ["module"]
+    }]
+  }
+}

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
-require('babel/register')({stage: 0});
+// require('babel/register')({stage: 0});
+require('babel/register')();
 var ipc = require('ipc');
 const app = require('app');  // Module to control application life.
 var BrowserWindow = require('browser-window');  // Module to create native browser window.

--- a/package.json
+++ b/package.json
@@ -34,12 +34,13 @@
     "url-loader": "^0.5.6"
   },
   "devDependencies": {
+    "babel-plugin-react-transform": "^1.0.5",
     "electron-prebuilt": "^0.32.3",
     "eslint": "^1.4.3",
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-react": "^3.3.2",
     "object-assign": "^4.0.1",
-    "react-hot-loader": "^1.3.0",
+    "react-transform-hmr": "^1.0.0",
     "webpack": "^1.12.1",
     "webpack-dev-server": "^1.11.0"
   }


### PR DESCRIPTION
The react-hot-loader has been deprecated. The new module is react-transform-hmr.