### PR TITLE
Create header menu

### DIFF
--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -1,0 +1,35 @@
+import React, {Component, PropTypes} from 'react';
+import { Link } from 'react-router';
+
+
+export default class Header extends Component {
+
+  render() {
+    return (
+      <div className="ui top fixed menu borderless">
+        <div className="item">
+          <img src="https://raw.githubusercontent.com/krolow/sqlectron/feature/adding-connection-screen/public/images/logo.png" style={{width: '5.5em'}} />
+        </div>
+        <div style={{margin: '0 auto'}}>
+          <div className="item borderless">
+            <div className="ui breadcrumb">
+              <i className="server icon"></i>
+              <a className="section">server-name</a>
+              <div className="divider"> / </div>
+              <i className="database icon"></i>
+              <div className="active section">database-name</div>
+            </div>
+          </div>
+        </div>
+        <div className="right menu" style={{marginLeft: '0 !important'}}>
+          <div className="item borderless">
+            <Link to="/" className="ui icon button" title="Close connection">
+              <i className="ban icon"></i>
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+};

--- a/src/containers/query-browser.jsx
+++ b/src/containers/query-browser.jsx
@@ -1,15 +1,16 @@
 import React, { Component, PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { Link } from 'react-router';
 import * as DatabaseActions from '../actions/databases.js';
 import * as QueryActions from '../actions/query.js';
 import DatabaseList from '../components/database-list.jsx';
 import Query from '../components/query.jsx';
+import Header from '../components/header.jsx';
 
 
 const STYLES = {
   wrapper: {
+    paddingTop: '50px'
   },
   header: {
 
@@ -56,18 +57,8 @@ export default class DatabaseListContainer extends Component {
     return (
       <div style={STYLES.wrapper}>
         <div style={STYLES.header}>
+          <Header />
         </div>
-
-        <div className="ui secondary menu">
-          <div className="right menu">
-            <div className="item">
-              <Link to="/" className="ui icon button" title="Close connection">
-                <i className="ban icon"></i>
-              </Link>
-            </div>
-          </div>
-        </div>
-
         <div style={STYLES.container}>
           <div style={STYLES.sidebar}>
             <div className="ui vertical menu">


### PR DESCRIPTION
Contains: Logo, current server and db and close connection button

![header](https://cloud.githubusercontent.com/assets/680356/9983669/f0e22710-5fdb-11e5-89d3-dcc2fd301813.png)

PS: The breadcrumb still static. To implement it properly we have to decide in which store we gonna keep the selected server and database. Lets decide it after finish the connection management screen.
